### PR TITLE
bugfixing in constant folding

### DIFF
--- a/R/opt-constant-folding.R
+++ b/R/opt-constant-folding.R
@@ -59,10 +59,14 @@ one_fold <- function(pd, fold_floats) {
       act_pd <- get_children(pd, act_parent)
       if (all(act_pd$token %in% c(constants, ops, precedence_ops, "expr"))) {
         # all the children are terminals or ops. try to evaluate it
-        act_code <- pd[pd$id == act_parent, "text"]
-        eval_val <- try({
-          eval(parse(text = act_code))
-        }, silent = TRUE)
+        act_code_pd <- pd[pd$id == act_parent,]
+        if (act_code_pd$token %in% c("STR_CONST", "NULL_CONST")) {
+          eval_val <- act_code_pd$text
+        } else {
+          eval_val <- try({
+            eval(parse(text = act_code_pd$text))
+          }, silent = TRUE)
+        }
         if (!inherits(eval_val, "try-error")) {
           # it was correctly evaluated then create the fpd of the eval val
           if (is.null(eval_val)) {

--- a/tests/testthat/test-opt_constant_folding.R
+++ b/tests/testthat/test-opt_constant_folding.R
@@ -220,3 +220,21 @@ test_that("constant fold NULL function", {
   expect_equal(names(env1), names(env1))
   expect_equal(env1$res, env2$res)
 })
+
+test_that("dont constant fold not assigned exprs", {
+  code <- paste(
+    "-2",
+    "2",
+    "NULL",
+    "\"hola\"",
+    sep = "\n"
+  )
+  opt_code <- opt_constant_folding(list(code))$codes[[1]]
+  expect_equal(opt_code, paste(
+    "-2",
+    "2",
+    "NULL",
+    "\"hola\"",
+    sep = "\n"
+  ))
+})


### PR DESCRIPTION
It was getting a bug when
```r
code <- paste(
    "\"hola\"",
    sep = "\n"
  )
  opt_code <- opt_constant_folding(list(code))
```