### PR TITLE
bugfixing in constant folding

### DIFF
--- a/R/opt-constant-folding.R
+++ b/R/opt-constant-folding.R
@@ -75,6 +75,13 @@ one_fold <- function(pd, fold_floats) {
           }
           res <- parse_flat_data(eval_val, include_text = TRUE)
           res <- flatten_leaves(res)
+          if (grepl("^\\{.+\\}$", act_code_pd$text)) {
+            # if it was `{expr}`, then add spaces in both sides
+            # there was a bug when folding `if(TRUE){-3}else{NULL}`
+            n_terms <- sum(res$terminal)
+            res[res$terminal,][1, "prev_spaces"] <- 1
+            res[res$terminal,][n_terms, "next_spaces"] <- 1
+          }
           if (all(res$token %in% c("expr", "'-'", constants))) {
             # it is a constant or -constant
             # replace the parent expr by the new expr (folded)

--- a/R/parse.R
+++ b/R/parse.R
@@ -184,12 +184,18 @@ replace_pd <- function(fpd_from, fpd_replace) {
   fst_term <- from_terms[which.min(from_terms$pos_id), ]
   last_term <- from_terms[which.max(from_terms$pos_id), ]
   new_terms <- new_fpd[new_fpd$terminal, "id"]
-  new_fpd[new_fpd$id == new_terms[[1]], "prev_spaces"] <-
-    fst_term$prev_spaces
-  new_fpd[new_fpd$id == new_terms[[length(new_terms)]], "next_spaces"] <-
-    last_term$next_spaces
-  new_fpd[new_fpd$id == new_terms[[length(new_terms)]], "next_lines"] <-
-    last_term$next_lines
+  if (fst_term$prev_spaces != 0) {
+    new_fpd[new_fpd$id == new_terms[[1]], "prev_spaces"] <-
+      fst_term$prev_spaces
+  }
+  if (last_term$next_spaces != 0) {
+    new_fpd[new_fpd$id == new_terms[[length(new_terms)]], "next_spaces"] <-
+      last_term$next_spaces
+  }
+  if (last_term$next_lines != 0) {
+    new_fpd[new_fpd$id == new_terms[[length(new_terms)]], "next_lines"] <-
+      last_term$next_lines
+  }
 
   return(new_fpd)
 }

--- a/tests/testthat/test-opt_constant_folding.R
+++ b/tests/testthat/test-opt_constant_folding.R
@@ -238,3 +238,15 @@ test_that("dont constant fold not assigned exprs", {
     sep = "\n"
   ))
 })
+
+test_that("add spaces when folding {const_expr}", {
+  code <- paste(
+    "if(TRUE){-3}else{NULL}",
+    sep = "\n"
+  )
+  opt_code <- opt_constant_folding(list(code))$codes[[1]]
+  expect_equal(opt_code, paste(
+    "if(TRUE) -3 else NULL ",
+    sep = "\n"
+  ))
+})


### PR DESCRIPTION
There was a bug when constant folding:
```r
if(TRUE){-3}else{NULL}
```
It was returning
```r
if(TRUE)-3elseNULL
```
