### PR TITLE
bugfixing in constant folding & dead code

### DIFF
--- a/Docker/optimize_rand_pkg.R
+++ b/Docker/optimize_rand_pkg.R
@@ -37,7 +37,7 @@ if (pkg_name == "") {
       act_pkg$Title, "\n\n"
     ))
   } else {
-    packages <- unlist(strsplit(packages[,2], ", "))
+    packages <- unlist(strsplit(packages[, 2], ", "))
     pkg_name <- packages[sample(seq_along(packages), 1)]
     cat(paste0(
       "\nPackage to test: ", pkg_name, "\n\n"
@@ -83,15 +83,31 @@ with_dir(pkg_dir_opt, {
   cat(paste0(paste(act_files[opt_files], collapse = "\n"), "\n"))
 })
 
+if (sum(opt_files) == 0) {
+  cat("Package not optimized.\n")
+  quit(save = "no")
+}
+
+# try to show diff between files
+if (.Platform$OS.type == "unix") {
+  bash_cmd <- paste(
+    paste0('ORIG_DIR="', pkg_name, '/R"'),
+    paste0('OPT_DIR="', pkg_name, '_opt/R"'),
+    "for FILE in $(ls $ORIG_DIR); do",
+    '  echo "********************************"',
+    "  echo $FILE",
+    "  diff $ORIG_DIR/$FILE $OPT_DIR/$FILE",
+    "done",
+    "",
+    sep = "\n"
+  )
+  try(system(bash_cmd))
+}
+
 # We finnished if the package does not have test cases or was not optimized
 if (!(file.exists(paste0(pkg_dir, "/tests/testthat.R")) &&
   file.exists(paste0(pkg_dir, "/tests/testthat/")))) {
   cat("Package does not contain testthat suite.\n")
-  quit(save = "no")
-}
-
-if (sum(opt_files) == 0) {
-  cat("Package not optimized.\n")
   quit(save = "no")
 }
 

--- a/R/opt-dead-code.R
+++ b/R/opt-dead-code.R
@@ -79,6 +79,13 @@ remove_after_interruption <- function(fpd) {
     id <- intr$parent[[i]]
     intr_prnt <- res_fpd[res_fpd$id == id, ]
     intr_sibl <- res_fpd[res_fpd$parent == id, ]
+    if (nrow(intr_sibl) > 5 &&
+        all(intr_sibl$token[c(1, 6)] == c("IF", "ELSE"))) {
+      # if these are intr siblings, then it is something like
+      # if (cond) return(...) else ...
+      # so dont remove
+      next
+    }
     keep_ids <- intr_sibl[seq_len(which(intr_sibl$id == intr$id[[i]])), "id"]
     # for each opening precedence op, keep one closing
     prec_sibl <- intr_sibl[intr_sibl$token %in% precedence_ops, "id"]

--- a/tests/testthat/test-opt_constant_folding.R
+++ b/tests/testthat/test-opt_constant_folding.R
@@ -250,3 +250,19 @@ test_that("add spaces when folding {const_expr}", {
     sep = "\n"
   ))
 })
+
+test_that("dont fold integer 'L' symbol", {
+  code <- paste(
+    'do_range_int <- function(x, halt_if_min = 1L, halt_if_max = -1L) {',
+    '  .Call(`_hutilscpp_do_range_int`, x, halt_if_min, halt_if_max)',
+    '}',
+    sep = "\n"
+  )
+  opt_code <- opt_constant_folding(list(code))$codes[[1]]
+  expect_equal(opt_code, paste(
+    'do_range_int <- function(x, halt_if_min = 1L, halt_if_max = -1L) {',
+    '  .Call(`_hutilscpp_do_range_int`, x, halt_if_min, halt_if_max)',
+    '}',
+    sep = "\n"
+  ))
+})

--- a/tests/testthat/test-opt_dead_code.R
+++ b/tests/testthat/test-opt_dead_code.R
@@ -229,3 +229,21 @@ test_that("replace TRUE if", {
     sep = "\n"
   ))
 })
+
+test_that("dont eliminate in `if return() else ...`", {
+  code <- paste(
+    'if (rhs) rhs else return(0L)',
+    'if (rhs) return(1L) else rhs',
+    'if (rhs) return(0L) else rhs',
+    'if (rhs) rhs else return(1L)',
+    sep = "\n"
+  )
+  opt_code <- opt_dead_code(list(code))$codes[[1]]
+  expect_equal(opt_code, paste(
+    'if (rhs) rhs else return(0L)',
+    'if (rhs) return(1L) else rhs',
+    'if (rhs) return(0L) else rhs',
+    'if (rhs) rhs else return(1L)',
+    sep = "\n"
+  ))
+})


### PR DESCRIPTION
two bugs fixed:
```r
if (rhs) return(1L) else rhs
```
was being wrongly optimized by dead code to
```r
if (rhs) return(1L)
```

And integers `10L` were constant folded to `10`.