### PR TITLE
bug fixing on CP

### DIFF
--- a/R/opt-constant-propagation.R
+++ b/R/opt-constant-propagation.R
@@ -277,7 +277,9 @@ only_uses_ops <- function(fpd, id) {
 #
 replace_constant_vars <- function(fpd, id, constant_vars) {
   # only edit SYMBOLS that are in the constant vars
-  to_edit <- fpd$token == "SYMBOL" & fpd$text %in% names(constant_vars)
+  to_edit <- fpd$token == "SYMBOL" & fpd$text %in% names(constant_vars) &
+    !sapply(fpd$parent, function(act_prnt) # dont replace SYMBOL$SYMBOL
+      "'$'" %in% fpd$token[fpd$parent == act_prnt])
   new_fpd <- fpd[!to_edit, ]
   to_edit_fpd <- fpd[to_edit, ]
   for (i in seq_len(nrow(to_edit_fpd))) {

--- a/tests/testthat/test-opt_constant_propagation.R
+++ b/tests/testthat/test-opt_constant_propagation.R
@@ -591,3 +591,21 @@ test_that("constant propagate function call", {
     sep = "\n"
   ))
 })
+
+test_that("dont propagate right to $ or @", {
+  code <- paste(
+    "name <- NULL",
+    "c(foo$name, foo@name)",
+    "foo$name",
+    "foo@name",
+    sep = "\n"
+  )
+  opt_code <- opt_constant_propagation(list(code))$codes[[1]]
+  expect_equal(opt_code, paste(
+    "name <- NULL",
+    "c(foo$name, foo@name)",
+    "foo$name",
+    "foo@name",
+    sep = "\n"
+  ))
+})


### PR DESCRIPTION
Constant propagation was replacing right side of `$`

```r
name <- NULL
c(foo$name, foo@name)
```